### PR TITLE
Add modmul native binding and tests

### DIFF
--- a/native/com_verificatum_vmgj_VMG.c
+++ b/native/com_verificatum_vmgj_VMG.c
@@ -90,6 +90,46 @@ extern "C" {
 
   /*
    * Class:     com_verificatum_vmgj_VMG
+   * Method:    modmul
+   * Signature: ([B[B[B)[B
+   */
+  JNIEXPORT jbyteArray JNICALL Java_com_verificatum_vmgj_VMG_modmul
+  (JNIEnv *env, jclass clazz, jbyteArray javaA, jbyteArray javaB,
+   jbyteArray javaModulus)
+  {
+    mpz_t a;
+    mpz_t b;
+    mpz_t modulus;
+    mpz_t result;
+    jbyteArray javaResult;
+
+    VMGJ_UNUSED(clazz);
+
+    /* Convert inputs to GMP integers. */
+    jbyteArray_to_mpz_t(env, &a, javaA);
+    jbyteArray_to_mpz_t(env, &b, javaB);
+    jbyteArray_to_mpz_t(env, &modulus, javaModulus);
+
+    /* Compute (a * b) mod modulus. */
+    mpz_init(result);
+    mpz_mul(result, a, b);
+    mpz_mod(result, result, modulus);
+
+    /* Convert result back to Java byte[]. */
+    mpz_t_to_jbyteArray(env, &javaResult, result);
+
+    /* Cleanup. */
+    mpz_clear(result);
+    mpz_clear(modulus);
+    mpz_clear(b);
+    mpz_clear(a);
+
+    return javaResult;
+  }
+
+
+  /*
+   * Class:     com_verificatum_vmgj_VMG
    * Method:    spowm
    * Signature: ([[B[[B[B)[B
    */

--- a/src/java/com/verificatum/vmgj/BenchVMG.java
+++ b/src/java/com/verificatum/vmgj/BenchVMG.java
@@ -116,6 +116,51 @@ public final class BenchVMG {
     }
 
     /**
+     * Times modular multiplication.
+     *
+     * @param bitLength Number of bits of integers in the operation
+     * timed.
+     * @param milliSecs Duration of the timing.
+     * @return Number of modular multiplications performed.
+     */
+    protected static long time_modmul(final int bitLength,
+                                      final long milliSecs) {
+
+        final SecureRandom random = new SecureRandom();
+
+        final int len = 100;
+
+        // Generate random modulus.
+        BigInteger modulus = new BigInteger(bitLength, random);
+        modulus = modulus.setBit(bitLength - 1);
+
+        final BigInteger[] lefts = new BigInteger[len];
+        final BigInteger[] rights = new BigInteger[len];
+
+        for (int l = 0; l < len; l++) {
+            lefts[l] = new BigInteger(bitLength, random);
+            lefts[l] = lefts[l].setBit(bitLength - 1);
+
+            rights[l] = new BigInteger(bitLength, random);
+            rights[l] = rights[l].setBit(bitLength - 1);
+        }
+
+        // Time optimized code.
+        final long t = System.currentTimeMillis();
+        long i = 0;
+        int l = 0;
+        while (!done(t, milliSecs)) {
+
+            VMG.modmul(lefts[l], rights[l], modulus);
+
+            l = (l + 1) % len;
+
+            i++;
+        }
+        return i;
+    }
+
+    /**
      * Times simultaneous exponentiation.
      *
      * @param bitLength Number of bits of integers in the operation
@@ -219,6 +264,8 @@ public final class BenchVMG {
 
         System.out.println(String.format("%12d exponentiations",
                                          time_powm(bitLength, milliSecs)));
+        System.out.println(String.format("%12d modular multiplications",
+                         time_modmul(bitLength, milliSecs)));
         System.out.println(String.format("%12d simultaneous exponentiations",
                                          time_spowm(bitLength, milliSecs)));
         System.out.println(String.format("%12d fixed-basis exponentiations",

--- a/src/java/com/verificatum/vmgj/TestVMG.java
+++ b/src/java/com/verificatum/vmgj/TestVMG.java
@@ -99,6 +99,32 @@ public final class TestVMG {
     }
 
     /**
+     * Tests modular multiplication.
+     *
+     * @param bitLength Number of bits of integers.
+     * @param milliSecs Duration of the timing.
+     */
+    protected static void test_modmul(final int bitLength,
+                                      final long milliSecs) {
+
+        final SecureRandom random = new SecureRandom();
+
+        // Test optimized code.
+        final long t = System.currentTimeMillis();
+        while (!done(t, milliSecs)) {
+
+            final BigInteger modulus = new BigInteger(bitLength, random);
+            final BigInteger a = new BigInteger(bitLength, random);
+            final BigInteger b = new BigInteger(bitLength, random);
+
+            final BigInteger vmg = VMG.modmul(a, b, modulus);
+            final BigInteger java = a.multiply(b).mod(modulus);
+
+            assert vmg.equals(java) : "Modular multiplication failed!";
+        }
+    }
+
+    /**
      * Test simultaneous exponentiation.
      *
      * @param bitLength Number of bits of integers.
@@ -374,6 +400,8 @@ public final class TestVMG {
 
         System.out.println("powm (plain modular exponentiation)");
         test_powm(bitLength, milliSecs);
+        System.out.println("modmul (modular multiplication)");
+        test_modmul(bitLength, milliSecs);
         System.out.println("spowm (simultaneous modular exponentiation)");
         test_spowm(bitLength, milliSecs);
         System.out.println("fpowm (fixed-basis modular exponentiation)");

--- a/src/java/com/verificatum/vmgj/VMG.magic
+++ b/src/java/com/verificatum/vmgj/VMG.magic
@@ -114,6 +114,36 @@ public final class VMG {
     }
 
     /**
+     * Computes the modular multiplication of two values using the
+     * given modulus.
+     *
+     * @param a First operand.
+     * @param b Second operand.
+     * @param modulus Modulus used during modular multiplication.
+     * @return Result of (a * b) mod modulus, given in two's complement.
+     */
+    static native byte[] modmul(byte[] a,
+                                byte[] b,
+                                byte[] modulus);
+
+    /**
+     * Computes the modular multiplication of two values using the
+     * given modulus.
+     *
+     * @param a First operand.
+     * @param b Second operand.
+     * @param modulus Modulus used during modular multiplication.
+     * @return Result of (a * b) mod modulus.
+     */
+    public static BigInteger modmul(final BigInteger a,
+                                    final BigInteger b,
+                                    final BigInteger modulus) {
+        return new BigInteger(modmul(a.toByteArray(),
+                                     b.toByteArray(),
+                                     modulus.toByteArray()));
+    }
+
+    /**
      * Computes a simultaneous modular exponentiation.
      *
      * @param bases Basis integers.


### PR DESCRIPTION
## Summary

- Add a native `modmul` binding and a Java wrapper for modular multiplication.
- Extend the test suite and benchmarks to cover `modmul`.

## Motivation

GMP’s modular multiplication is approximately 2.5× faster than the equivalent native Java operation in our measurements.  
Applications that perform millions of modular multiplications, such as cryptographic protocols and number-theoretic workloads, benefit significantly from a JNI wrapper, reducing overall runtime and CPU usage.

## Testing

- `make check`
- `make bench`
