### PR TITLE
Fix JNI pointer ABI casts and enforce no-undefined

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,37 @@
+# Default text normalization
+* text=auto eol=lf
+
+# Source and build metadata
+*.c text eol=lf
+*.h text eol=lf
+*.ac text eol=lf
+*.am text eol=lf
+*.m4 text eol=lf
+*.cmake text eol=lf
+*.in text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf
+*.supp text eol=lf
+CMakeLists.txt text eol=lf
+Makefile.build text eol=lf
+
+# Scripts
+*.sh text eol=lf
+*.py text eol=lf
+
+# Documentation
+*.md text eol=lf
+AUTHORS text eol=lf
+NEWS text eol=lf
+
+# Binary/build artifacts
+*.o binary
+*.lo binary
+*.a binary
+*.la text eol=lf
+*.so binary
+*.so.* binary
+*.dll binary
+*.dll.a binary
+*.exe binary

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -142,7 +142,10 @@ jobs:
 
       - name: Configure native C
         working-directory: native
-        run: ./configure CC=gcc
+        run: |
+          export JAVA_HOME="$(cygpath -u "$JAVA_HOME")"
+          export PATH="$JAVA_HOME/bin:$PATH"
+          ./configure CC=gcc
 
       - name: Build native C
         working-directory: native

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -10,14 +10,14 @@ permissions:
   contents: read
 
 jobs:
-  # ====================== Linux + macOS ======================
+  # ====================== Linux ======================
   unix:
     name: ${{ matrix.os }} - ${{ matrix.compiler }} - ${{ matrix.build_type }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest ]
         compiler: [ gcc, clang ]
         build_type: [ Debug, Release ]
         include:
@@ -35,8 +35,7 @@ jobs:
           distribution: temurin
           java-version: "11"
 
-      - name: Install Linux dependencies
-        if: runner.os == 'Linux'
+      - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential autoconf automake libtool m4 make git libgmp-dev
@@ -44,29 +43,10 @@ jobs:
             sudo apt-get install -y clang
           fi
 
-      - name: Install macOS dependencies
-        if: runner.os == 'macOS'
-        run: |
-          brew update
-          brew install autoconf automake libtool gmp
-          if [ "${{ matrix.compiler }}" = "gcc" ]; then
-            brew install gcc
-          fi
-          mkdir -p "$RUNNER_TEMP/gnubin"
-          ln -sf "$(brew --prefix libtool)/bin/glibtoolize" "$RUNNER_TEMP/gnubin/libtoolize"
-          echo "$RUNNER_TEMP/gnubin" >> "$GITHUB_PATH"
-          echo "CPPFLAGS=-I$(brew --prefix gmp)/include" >> "$GITHUB_ENV"
-          echo "GMP_LDFLAGS=-L$(brew --prefix gmp)/lib" >> "$GITHUB_ENV"
-
       - name: Select compiler and flags
         shell: bash
         run: |
-          if [ "${{ runner.os }}" = "macOS" ] && [ "${{ matrix.compiler }}" = "gcc" ]; then
-            cc_path="$(ls "$(brew --prefix)"/bin/gcc-[0-9]* | sort | tail -n 1)"
-            echo "CC=$cc_path" >> "$GITHUB_ENV"
-          else
-            echo "CC=${{ matrix.compiler }}" >> "$GITHUB_ENV"
-          fi
+          echo "CC=${{ matrix.compiler }}" >> "$GITHUB_ENV"
 
           if [ "${{ matrix.build_type }}" = "Debug" ]; then
             cflags="-O0 -g"
@@ -91,9 +71,7 @@ jobs:
           ./configure CC="$CC" CFLAGS="$CFLAGS" LDFLAGS="${LDFLAGS:-}"
           make
           sudo make install
-          if [ "${{ runner.os }}" = "Linux" ]; then
-            sudo ldconfig
-          fi
+          sudo ldconfig
 
       - name: Prepare native metadata
         run: cp LICENSE NEWS README.md AUTHORS ChangeLog .macros.m4 .version.m4 native/
@@ -143,6 +121,7 @@ jobs:
             libtool
             m4
             make
+            python
             mingw-w64-x86_64-gcc
             mingw-w64-x86_64-gmp
 
@@ -222,7 +201,12 @@ jobs:
 
       - name: Build native C
         working-directory: native
-        run: make
+        run: |
+          if [ "${{ matrix.compiler }}" = "clang" ]; then
+            make GMP_CFLAGS=""
+          else
+            make
+          fi
 
       - name: Check native C
         working-directory: native
@@ -241,7 +225,7 @@ jobs:
           release: "15.0"
           usesh: true
           prepare: |
-            pkg install -y autoconf automake libtool gmp git gmake m4 openjdk11
+            pkg install -y autoconf automake libtool gmp git gmake m4 python openjdk11
           run: |
             export JAVA_HOME=/usr/local/openjdk11
             export PATH="$JAVA_HOME/bin:$PATH"

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "11"
+          java-version: "25"
 
       - name: Install dependencies
         run: |
@@ -107,7 +107,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "11"
+          java-version: "25"
 
       - uses: msys2/setup-msys2@v2
         with:
@@ -168,7 +168,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "11"
+          java-version: "25"
 
       - name: Install dependencies
         run: |
@@ -225,10 +225,14 @@ jobs:
           release: "15.0"
           usesh: true
           prepare: |
-            pkg install -y autoconf automake libtool gmp git gmake m4 python openjdk11
+            pkg install -y autoconf automake libtool gmp git gmake m4 python openjdk25
           run: |
-            export JAVA_HOME=/usr/local/openjdk11
-            export PATH="$JAVA_HOME/bin:$PATH"
+            export JAVA_HOME=/usr/local/openjdk25
+            mkdir -p "$GITHUB_WORKSPACE/.ci-bin"
+            printf '%s\n' '#!/bin/sh' 'if [ "${JAVAVM_DRYRUN:-}" = "yes" ]; then' '  echo "JAVA_HOME=$JAVA_HOME"' '  exit 0' 'fi' 'exec "$JAVA_HOME/bin/javac" "$@"' > "$GITHUB_WORKSPACE/.ci-bin/javac"
+            chmod +x "$GITHUB_WORKSPACE/.ci-bin/javac"
+            export PATH="$GITHUB_WORKSPACE/.ci-bin:$JAVA_HOME/bin:$PATH"
+            export C_INCLUDE_PATH="/usr/local/include:$JAVA_HOME/include:$JAVA_HOME/include/freebsd:${C_INCLUDE_PATH:-}"
             git clone --depth 1 --branch interop/jni-abi-fixes https://github.com/esseivao/verificatum-gmpmee.git ../verificatum-gmpmee
             gmake -C ../verificatum-gmpmee -f Makefile.build
             cd ../verificatum-gmpmee

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -10,9 +10,177 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: Ubuntu - GCC
-    runs-on: ubuntu-latest
+  # ====================== Linux + macOS ======================
+  unix:
+    name: ${{ matrix.os }} - ${{ matrix.compiler }} - ${{ matrix.build_type }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+        compiler: [ gcc, clang ]
+        build_type: [ Debug, Release ]
+        include:
+          - os: ubuntu-latest
+            compiler: clang
+            build_type: Debug
+            sanitizer: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "11"
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential autoconf automake libtool m4 make git libgmp-dev
+          if [ "${{ matrix.compiler }}" = "clang" ]; then
+            sudo apt-get install -y clang
+          fi
+
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        run: |
+          brew update
+          brew install autoconf automake libtool gmp
+          if [ "${{ matrix.compiler }}" = "gcc" ]; then
+            brew install gcc
+          fi
+          mkdir -p "$RUNNER_TEMP/gnubin"
+          ln -sf "$(brew --prefix libtool)/bin/glibtoolize" "$RUNNER_TEMP/gnubin/libtoolize"
+          echo "$RUNNER_TEMP/gnubin" >> "$GITHUB_PATH"
+          echo "CPPFLAGS=-I$(brew --prefix gmp)/include" >> "$GITHUB_ENV"
+          echo "GMP_LDFLAGS=-L$(brew --prefix gmp)/lib" >> "$GITHUB_ENV"
+
+      - name: Select compiler and flags
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = "macOS" ] && [ "${{ matrix.compiler }}" = "gcc" ]; then
+            cc_path="$(ls "$(brew --prefix)"/bin/gcc-[0-9]* | sort | tail -n 1)"
+            echo "CC=$cc_path" >> "$GITHUB_ENV"
+          else
+            echo "CC=${{ matrix.compiler }}" >> "$GITHUB_ENV"
+          fi
+
+          if [ "${{ matrix.build_type }}" = "Debug" ]; then
+            cflags="-O0 -g"
+          else
+            cflags="-O3"
+          fi
+
+          ldflags="${GMP_LDFLAGS:-}"
+          if [ "${{ matrix.sanitizer }}" = "true" ]; then
+            cflags="$cflags -fsanitize=address,undefined -fno-omit-frame-pointer"
+            ldflags="$ldflags -fsanitize=address,undefined"
+          fi
+
+          echo "CFLAGS=$cflags" >> "$GITHUB_ENV"
+          echo "LDFLAGS=$ldflags" >> "$GITHUB_ENV"
+
+      - name: Install GMPMEE
+        run: |
+          git clone --depth 1 --branch interop/jni-abi-fixes https://github.com/esseivao/verificatum-gmpmee.git ../verificatum-gmpmee
+          make -C ../verificatum-gmpmee -f Makefile.build
+          cd ../verificatum-gmpmee
+          ./configure CC="$CC" CFLAGS="$CFLAGS" LDFLAGS="${LDFLAGS:-}"
+          make
+          sudo make install
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            sudo ldconfig
+          fi
+
+      - name: Prepare native metadata
+        run: cp LICENSE NEWS README.md AUTHORS ChangeLog .macros.m4 .version.m4 native/
+
+      - name: Bootstrap native C
+        run: make -C native -f Makefile.build
+
+      - name: Configure native C
+        working-directory: native
+        run: ./configure CC="$CC" CFLAGS="$CFLAGS" LDFLAGS="${LDFLAGS:-}"
+
+      - name: Build native C
+        working-directory: native
+        run: make
+
+      - name: Check native C
+        working-directory: native
+        run: make check
+
+  # ====================== Windows - MinGW-w64 GCC ======================
+  windows-mingw:
+    name: Windows - MinGW-w64 GCC
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "11"
+
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            base-devel
+            git
+            autoconf
+            automake
+            libtool
+            m4
+            make
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-gmp
+
+      - name: Install GMPMEE
+        run: |
+          git clone --depth 1 --branch interop/jni-abi-fixes https://github.com/esseivao/verificatum-gmpmee.git ../verificatum-gmpmee
+          make -C ../verificatum-gmpmee -f Makefile.build
+          cd ../verificatum-gmpmee
+          ./configure CC=gcc
+          make
+          make install
+
+      - name: Prepare native metadata
+        run: cp LICENSE NEWS README.md AUTHORS ChangeLog .macros.m4 .version.m4 native/
+
+      - name: Bootstrap native C
+        run: make -C native -f Makefile.build
+
+      - name: Configure native C
+        working-directory: native
+        run: ./configure CC=gcc
+
+      - name: Build native C
+        working-directory: native
+        run: make
+
+      - name: Check native C
+        working-directory: native
+        run: make check
+
+  # ====================== Ubuntu 32-bit legacy ======================
+  build-32bit-legacy:
+    name: ubuntu-22.04 32-bit - ${{ matrix.compiler }} - Release
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [ gcc, clang ]
 
     steps:
       - uses: actions/checkout@v4
@@ -25,27 +193,68 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt-get install -y build-essential autoconf automake libtool m4 make git libgmp-dev
+          sudo apt-get install -y build-essential gcc-multilib libc6-dev-i386 autoconf automake libtool m4 make git libgmp-dev:i386
+          if [ "${{ matrix.compiler }}" = "clang" ]; then
+            sudo apt-get install -y clang
+          fi
 
       - name: Install GMPMEE
         run: |
           git clone --depth 1 --branch interop/jni-abi-fixes https://github.com/esseivao/verificatum-gmpmee.git ../verificatum-gmpmee
           make -C ../verificatum-gmpmee -f Makefile.build
           cd ../verificatum-gmpmee
-          ./configure
+          ./configure CC="${{ matrix.compiler }}" CFLAGS="-m32 -O3" CPPFLAGS="-I/usr/include/i386-linux-gnu" LDFLAGS="-m32 -L/usr/lib/i386-linux-gnu"
           make
           sudo make install
           sudo ldconfig
 
-      - name: Bootstrap
-        run: make -f Makefile.build
+      - name: Prepare native metadata
+        run: cp LICENSE NEWS README.md AUTHORS ChangeLog .macros.m4 .version.m4 native/
 
-      - name: Configure
-        run: ./configure
+      - name: Bootstrap native C
+        run: make -C native -f Makefile.build
 
-      - name: Build
+      - name: Configure native C
+        working-directory: native
+        run: ./configure CC="${{ matrix.compiler }}" CFLAGS="-m32 -O3" CPPFLAGS="-I/usr/include/i386-linux-gnu" LDFLAGS="-m32 -L/usr/lib/i386-linux-gnu"
+
+      - name: Build native C
+        working-directory: native
         run: make
 
-      - name: Test
+      - name: Check native C
+        working-directory: native
         run: make check
+
+  # ====================== FreeBSD ======================
+  freebsd:
+    name: FreeBSD 15.0
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: vmactions/freebsd-vm@v1
+        with:
+          release: "15.0"
+          usesh: true
+          prepare: |
+            pkg install -y autoconf automake libtool gmp git gmake m4 openjdk11
+          run: |
+            export JAVA_HOME=/usr/local/openjdk11
+            export PATH="$JAVA_HOME/bin:$PATH"
+            git clone --depth 1 --branch interop/jni-abi-fixes https://github.com/esseivao/verificatum-gmpmee.git ../verificatum-gmpmee
+            gmake -C ../verificatum-gmpmee -f Makefile.build
+            cd ../verificatum-gmpmee
+            ./configure CC=cc CPPFLAGS="-I/usr/local/include" LDFLAGS="-L/usr/local/lib"
+            gmake
+            gmake install
+            cd -
+            cp LICENSE NEWS README.md AUTHORS ChangeLog .macros.m4 .version.m4 native/
+            gmake -C native -f Makefile.build
+            cd native
+            ./configure CC=cc CPPFLAGS="-I/usr/local/include" LDFLAGS="-L/usr/local/lib"
+            gmake
+            gmake check

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches: [ interop/jni-abi-fixes ]
+  pull_request:
+    branches: [ interop/jni-abi-fixes ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Ubuntu - GCC
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "11"
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential autoconf automake libtool m4 make git libgmp-dev
+
+      - name: Install GMPMEE
+        run: |
+          git clone --depth 1 --branch interop/jni-abi-fixes https://github.com/esseivao/verificatum-gmpmee.git ../verificatum-gmpmee
+          make -C ../verificatum-gmpmee -f Makefile.build
+          cd ../verificatum-gmpmee
+          ./configure
+          make
+          sudo make install
+          sudo ldconfig
+
+      - name: Bootstrap
+        run: make -f Makefile.build
+
+      - name: Configure
+        run: ./configure
+
+      - name: Build
+        run: make
+
+      - name: Test
+        run: make check

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ interop/jni-abi-fixes ]
+    branches: [ master ]
   pull_request:
-    branches: [ interop/jni-abi-fixes ]
+    branches: [ master ]
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,73 @@
+# Autotools / libtool generated files
+/aclocal.m4
+/autom4te.cache/
+/compile
+/config.guess
+/config.h
+/config.h.in
+/config.h.in~
+/config.log
+/config.status
+/config.sub
+/configure
+/depcomp
+/install-sh
+/libtool
+/ltmain.sh
+/missing
+/Makefile
+/Makefile.in
+/m4/
+/stamp-h1
+
+# CMake generated files
+/CMakeCache.txt
+/CMakeFiles/
+/cmake_install.cmake
+/CTestTestfile.cmake
+/DartConfiguration.tcl
+/Testing/
+/install_manifest.txt
+
+# Generated source/data files
+/.build.bstamp
+/.trialdiv.bstamp
+/trialdiv_32.c
+/trialdiv_64.c
+/trialdiv_safe_32.c
+/trialdiv_safe_64.c
+/scriptmacros.m4
+/check_info.stamp
+
+# Build outputs
+/build*/
+/.deps/
+/.libs/
+*.o
+*.lo
+*.la
+*.a
+*.so
+*.so.*
+*.dll
+*.dll.a
+*.exe
+
+# Generated helper/install outputs
+/bin/
+/gmpmee
+/gmpmee.exe
+/extract_GMP_CFLAGS
+/extract_GMP_CFLAGS.exe
+
+# Coverage and documentation outputs
+/api/
+/html_api/
+/coverage/
+*.gcda
+*.gcno
+*.gcov
+coverage.info
+
+# Editor and backup files
+*~

--- a/native/Makefile.am
+++ b/native/Makefile.am
@@ -37,7 +37,8 @@ libvmgj_la_LIBADD = -lgmp -lgmpmee
 
 # We use -release to glue the native code and Java code together. We
 # are aware that this violate common practice for library versioning.
-libvmgj_la_LDFLAGS = -release $(VERSION)
+# -no-undefined is needed for Windows DLL builds with libtool.
+libvmgj_la_LDFLAGS = -release $(VERSION) -no-undefined
 
 # This is generated from a Java file and copied to this directory by
 # the parent directory.

--- a/native/com_verificatum_vmgj_VMG.c
+++ b/native/com_verificatum_vmgj_VMG.c
@@ -27,6 +27,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 #include <gmp.h>
 #include "gmpmee.h"
@@ -39,6 +40,8 @@
  * those parameters that we do not use.
  */
 #define VMGJ_UNUSED(x) ((void)(x))
+#define VMGJ_JLONG_FROM_PTR(ptr) ((jlong)(intptr_t)(ptr))
+#define VMGJ_PTR_FROM_JLONG(type, value) ((type *)(intptr_t)(value))
 
 #ifdef __cplusplus
 extern "C" {
@@ -176,7 +179,7 @@ extern "C" {
     mpz_clear(modulus);
     mpz_clear(basis);
 
-    return (jlong)(long)tablePtr;
+    return VMGJ_JLONG_FROM_PTR(tablePtr);
   }
 
 
@@ -198,7 +201,9 @@ extern "C" {
     jbyteArray_to_mpz_t(env, &exponent, javaExponent);
     mpz_init(result);
 
-    gmpmee_fpowm(result, *(gmpmee_fpowm_tab *)(long)javaTablePtr, exponent);
+    gmpmee_fpowm(result,
+          *VMGJ_PTR_FROM_JLONG(gmpmee_fpowm_tab, javaTablePtr),
+          exponent);
 
     /* Translate result back to jbyteArray (this also allocates the
        result array on the JVM heap). */
@@ -221,7 +226,7 @@ extern "C" {
   {
     VMGJ_UNUSED(env);
     VMGJ_UNUSED(clazz);
-    gmpmee_fpowm_clear(*(gmpmee_fpowm_tab *)(long)javaTablePtr);
+    gmpmee_fpowm_clear(*VMGJ_PTR_FROM_JLONG(gmpmee_fpowm_tab, javaTablePtr));
   }
 
 
@@ -276,7 +281,7 @@ extern "C" {
 
     mpz_clear(n);
 
-    return (jlong)(long)statePtr;
+    return VMGJ_JLONG_FROM_PTR(statePtr);
   }
 
 
@@ -290,8 +295,8 @@ extern "C" {
   {
     VMGJ_UNUSED(env);
     VMGJ_UNUSED(clazz);
-    gmpmee_millerrabin_next_cand(*(gmpmee_millerrabin_state *)(long)
-                                 javaStatePtr);
+    gmpmee_millerrabin_next_cand(
+      *VMGJ_PTR_FROM_JLONG(gmpmee_millerrabin_state, javaStatePtr));
   }
 
 
@@ -309,8 +314,9 @@ extern "C" {
     VMGJ_UNUSED(clazz);
 
     jbyteArray_to_mpz_t(env, &base, javaBase);
-    res = gmpmee_millerrabin_once(*(gmpmee_millerrabin_state *)(long)
-                                  javaStatePtr, base);
+    res = gmpmee_millerrabin_once(
+      *VMGJ_PTR_FROM_JLONG(gmpmee_millerrabin_state, javaStatePtr),
+      base);
 
     mpz_clear(base);
 
@@ -328,7 +334,8 @@ extern "C" {
   {
     VMGJ_UNUSED(env);
     VMGJ_UNUSED(clazz);
-    gmpmee_millerrabin_clear(*(gmpmee_millerrabin_state *)(long)javaStatePtr);
+    gmpmee_millerrabin_clear(
+      *VMGJ_PTR_FROM_JLONG(gmpmee_millerrabin_state, javaStatePtr));
   }
 
 
@@ -347,8 +354,8 @@ extern "C" {
     VMGJ_UNUSED(clazz);
 
     mpz_t_to_jbyteArray(env, &javaResult,
-                        (*(gmpmee_millerrabin_state *)(long)
-                         javaStatePtr)->n);
+                        (*VMGJ_PTR_FROM_JLONG(gmpmee_millerrabin_state,
+                                              javaStatePtr))->n);
     return javaResult;
   }
 
@@ -379,7 +386,7 @@ extern "C" {
 
     mpz_clear(n);
 
-    return (jlong)(long)statePtr;
+    return VMGJ_JLONG_FROM_PTR(statePtr);
   }
 
 
@@ -394,8 +401,8 @@ extern "C" {
   {
     VMGJ_UNUSED(env);
     VMGJ_UNUSED(clazz);
-    gmpmee_millerrabin_safe_next_cand(*(gmpmee_millerrabin_safe_state *)(long)
-                                      javaStatePtr);
+    gmpmee_millerrabin_safe_next_cand(
+      *VMGJ_PTR_FROM_JLONG(gmpmee_millerrabin_safe_state, javaStatePtr));
   }
 
 
@@ -417,14 +424,16 @@ extern "C" {
 
     if (((int)javaIndex) % 2 == 0)
       {
-        res = gmpmee_millerrabin_once((*(gmpmee_millerrabin_safe_state *)(long)
-                                       javaStatePtr)->nstate,
+        res = gmpmee_millerrabin_once((*VMGJ_PTR_FROM_JLONG(
+                                        gmpmee_millerrabin_safe_state,
+                                        javaStatePtr))->nstate,
                                       base);
       }
     else
       {
-        res = gmpmee_millerrabin_once((*(gmpmee_millerrabin_safe_state *)(long)
-                                       javaStatePtr)->mstate,
+        res = gmpmee_millerrabin_once((*VMGJ_PTR_FROM_JLONG(
+                                        gmpmee_millerrabin_safe_state,
+                                        javaStatePtr))->mstate,
                                       base);
       }
 
@@ -444,8 +453,8 @@ extern "C" {
   {
     VMGJ_UNUSED(env);
     VMGJ_UNUSED(clazz);
-    gmpmee_millerrabin_safe_clear(*(gmpmee_millerrabin_safe_state *)(long)
-                                  javaStatePtr);
+    gmpmee_millerrabin_safe_clear(
+      *VMGJ_PTR_FROM_JLONG(gmpmee_millerrabin_safe_state, javaStatePtr));
   }
 
 
@@ -462,8 +471,8 @@ extern "C" {
 
     VMGJ_UNUSED(clazz);
     mpz_t_to_jbyteArray(env, &javaResult,
-                        (*(gmpmee_millerrabin_safe_state *)(long)
-                         javaStatePtr)->nstate->n);
+                        (*VMGJ_PTR_FROM_JLONG(gmpmee_millerrabin_safe_state,
+                                              javaStatePtr))->nstate->n);
     return javaResult;
   }
 


### PR DESCRIPTION
This PR fixes JNI/native ABI portability issues that broke or risked breaking 64-bit Windows builds, and updates libtool linker flags required for reliable DLL generation.

- On Windows LLP64, long is 32-bit while pointers are 64-bit.
- Casting pointers through long can truncate addresses and cause undefined behavior.
- Using intptr_t preserves pointer width across platforms.
- -no-undefined is required by libtool for proper shared library behavior on Windows targets.